### PR TITLE
Feature/concert endpoint revision

### DIFF
--- a/jamjar/jamjar/concerts/models.py
+++ b/jamjar/jamjar/concerts/models.py
@@ -2,7 +2,6 @@ from django.db import models
 
 from jamjar.base.models import BaseModel
 from jamjar.videos.models import Edge
-from jamjar.videos.serializers import VideoSerializer
 from jamjar.artists.serializers import ArtistSerializer
 
 from concert_graph import ConcertGraph

--- a/jamjar/jamjar/concerts/models.py
+++ b/jamjar/jamjar/concerts/models.py
@@ -2,7 +2,6 @@ from django.db import models
 
 from jamjar.base.models import BaseModel
 from jamjar.videos.models import Edge
-from jamjar.artists.serializers import ArtistSerializer
 
 from concert_graph import ConcertGraph
 
@@ -17,14 +16,3 @@ class Concert(BaseModel):
 
         g = ConcertGraph(concert_edges)
         return g.disjoint_graphs()
-
-    def artists(self):
-        found_artists = []
-        seen_ids = set()
-
-        for video in self.videos.all():
-            for artist in video.artists.all():
-                if artist.id not in seen_ids:
-                  found_artists.append(artist)
-                  seen_ids.add(artist.id)
-        return ArtistSerializer(found_artists, many=True).data

--- a/jamjar/jamjar/concerts/serializers.py
+++ b/jamjar/jamjar/concerts/serializers.py
@@ -74,8 +74,9 @@ class ConcertSerializer(serializers.ModelSerializer):
     def get_thumbs(self,obj):
         """
         Return the thumbnails from the first 3 videos in the concert (or all
-        videos if there's < 3)
+        videos if there's <= 3)
         """
         first_videos = obj.videos.all()[:3]
-        thumbs = [video.thumb_src() for video in first_videos]
+        # import ipdb; ipdb.set_trace()
+        thumbs = [video.thumb_src() for video in first_videos if video.thumb_src() is not None]
         return thumbs

--- a/jamjar/jamjar/concerts/serializers.py
+++ b/jamjar/jamjar/concerts/serializers.py
@@ -12,10 +12,11 @@ class ConcertSerializer(serializers.ModelSerializer):
     venue = VenueSerializer(required=False, read_only=True)
     venue_place_id = serializers.CharField(max_length=100,write_only=True, required=False)
     videos = VideoSerializer(many=True, read_only=True)
+    thumbs = serializers.SerializerMethodField()
 
     class Meta:
         model = Concert
-        fields = ('id', 'date', 'venue_place_id', 'venue', 'videos', 'artists')
+        fields = ('id', 'date', 'venue_place_id', 'venue', 'videos', 'artists','thumbs')
         read_only_fields = ('id', 'venue', 'videos')
         write_only_fields = ('venue_place_id')
 
@@ -70,4 +71,11 @@ class ConcertSerializer(serializers.ModelSerializer):
 
         return concert
 
-    # def update(self, instance, validated_data):
+    def get_thumbs(self,obj):
+        """
+        Return the thumbnails from the first 3 videos in the concert (or all
+        videos if there's < 3)
+        """
+        first_videos = obj.videos.all()[:3]
+        thumbs = [video.thumb_src() for video in first_videos]
+        return thumbs

--- a/jamjar/jamjar/concerts/serializers.py
+++ b/jamjar/jamjar/concerts/serializers.py
@@ -2,7 +2,8 @@ from rest_framework import serializers
 from jamjar.concerts.models import Concert
 from jamjar.venues.models import Venue
 from jamjar.videos.serializers import VideoSerializer
-
+from jamjar.artists.models import Artist
+from jamjar.artists.serializers import ArtistSerializer
 from jamjar.venues.serializers import VenueSerializer
 from jamjar.common.services import GMapService, ServiceError
 
@@ -13,6 +14,7 @@ class ConcertSerializer(serializers.ModelSerializer):
     venue_place_id = serializers.CharField(max_length=100,write_only=True, required=False)
     videos = VideoSerializer(many=True, read_only=True)
     thumbs = serializers.SerializerMethodField()
+    artists = serializers.SerializerMethodField()
 
     class Meta:
         model = Concert
@@ -71,7 +73,7 @@ class ConcertSerializer(serializers.ModelSerializer):
 
         return concert
 
-    def get_thumbs(self,obj):
+    def get_thumbs(self, obj):
         """
         Return the thumbnails from the first 3 videos in the concert (or all
         videos if there's <= 3)
@@ -80,3 +82,7 @@ class ConcertSerializer(serializers.ModelSerializer):
         # import ipdb; ipdb.set_trace()
         thumbs = [video.thumb_src() for video in first_videos if video.thumb_src() is not None]
         return thumbs
+
+    def get_artists(self, obj):
+        artists = Artist.objects.filter(videos__concert_id=obj.id).distinct()
+        return ArtistSerializer(artists, many=True).data

--- a/jamjar/jamjar/concerts/views.py
+++ b/jamjar/jamjar/concerts/views.py
@@ -5,25 +5,6 @@ from jamjar.concerts.serializers import ConcertSerializer
 
 import datetime
 
-class ConcertGraph(BaseView):
-    serializer_class = ConcertSerializer
-
-    @authenticate
-    def get(self, request, id):
-         # Attempt to get the video
-        try:
-            self.concert = Concert.objects.get(id=id)
-        except:
-            return self.error_response('Concert does not exist or you do not have access to this concert.', 404)
-
-        concert_graph = self.concert.make_graph()
-        resp = {
-            "graph": concert_graph,
-            "concert": ConcertSerializer(self.concert).data
-        }
-
-        return self.success_response(resp)
-
 class ConcertListView(BaseView):
     serializer_class = ConcertSerializer
 
@@ -71,7 +52,7 @@ class ConcertListView(BaseView):
             queryset = queryset.filter(videos__artists__id__in=artist_filters)
 
         # Serialize the requests and return them
-        self.serializer = self.get_serializer(queryset, many=True, expand_videos=False)
+        self.serializer = self.get_serializer(queryset, many=True)
         return self.success_response(self.serializer.data)
 
 
@@ -157,6 +138,6 @@ class ConcertDetailView(BaseView):
     """
     @authenticate
     def get(self, request, id):
-        self.concert = self.get_object_or_404(Concert,pk=id)
-        self.serializer = self.get_serializer(self.concert)
+        self.concert = self.get_object_or_404(Concert, pk=id)
+        self.serializer = self.get_serializer(self.concert, expand_videos=True, include_graph=True)
         return self.success_response(self.serializer.data)

--- a/jamjar/jamjar/concerts/views.py
+++ b/jamjar/jamjar/concerts/views.py
@@ -55,7 +55,7 @@ class ConcertView(BaseView):
     @authenticate
     def get(self, request, id):
         self.concert = self.get_object_or_404(Concert,pk=id)
-        self.serializer = self.get_serializer(self.concert)
+        self.serializer = self.get_serializer(self.concert,expand_videos=False)
         return self.success_response(self.serializer.data)
 
 

--- a/jamjar/jamjar/concerts/views.py
+++ b/jamjar/jamjar/concerts/views.py
@@ -22,43 +22,6 @@ class ConcertGraph(BaseView):
 
         return self.success_response(resp)
 
-class ConcertView(BaseView):
-    serializer_class = ConcertSerializer
-
-    """
-    Description:
-        Get a Concert by id
-    Request:
-        GET /concerts/:id/
-    Response:
-        {
-          "id": 1,
-          "date": "2016-02-04",
-          "venue": {
-            "id": 1,
-            "name": "Union Transfer",
-            "place_id": "ChIJPWg_kNXHxokRPXdE7nqMsI4",
-            "unofficial": false,
-            "formatted_address": "1026 Spring Garden St, Philadelphia, PA 19123, United States",
-            "lat": "39.96138760",
-            "lng": "-75.15532360",
-            "utc_offset": -300,
-            "website": "http://www.utphilly.com/",
-            "city": "Philadelphia",
-            "state": "Pennsylvania",
-            "state_short": "PA",
-            "country": "United States",
-            "country_short": "US"
-          }
-        }
-    """
-    @authenticate
-    def get(self, request, id):
-        self.concert = self.get_object_or_404(Concert,pk=id)
-        self.serializer = self.get_serializer(self.concert,expand_videos=False)
-        return self.success_response(self.serializer.data)
-
-
 class ConcertListView(BaseView):
     serializer_class = ConcertSerializer
 
@@ -75,7 +38,7 @@ class ConcertListView(BaseView):
         objects = Concert.objects.all()
 
         # Serialize the requests and return them
-        self.serializer = self.get_serializer(objects, many=True)
+        self.serializer = self.get_serializer(objects, many=True, expand_videos=False)
         return self.success_response(self.serializer.data)
 
 
@@ -127,4 +90,40 @@ class ConcertListView(BaseView):
         except IntegrityError as e:
             return self.error_response(str(e), 400)
 
+        return self.success_response(self.serializer.data)
+
+class ConcertDetailView(BaseView):
+    serializer_class = ConcertSerializer
+
+    """
+    Description:
+        Get a Concert by id
+    Request:
+        GET /concerts/:id/
+    Response:
+        {
+          "id": 1,
+          "date": "2016-02-04",
+          "venue": {
+            "id": 1,
+            "name": "Union Transfer",
+            "place_id": "ChIJPWg_kNXHxokRPXdE7nqMsI4",
+            "unofficial": false,
+            "formatted_address": "1026 Spring Garden St, Philadelphia, PA 19123, United States",
+            "lat": "39.96138760",
+            "lng": "-75.15532360",
+            "utc_offset": -300,
+            "website": "http://www.utphilly.com/",
+            "city": "Philadelphia",
+            "state": "Pennsylvania",
+            "state_short": "PA",
+            "country": "United States",
+            "country_short": "US"
+          }
+        }
+    """
+    @authenticate
+    def get(self, request, id):
+        self.concert = self.get_object_or_404(Concert,pk=id)
+        self.serializer = self.get_serializer(self.concert)
         return self.success_response(self.serializer.data)

--- a/jamjar/jamjar/concerts/views.py
+++ b/jamjar/jamjar/concerts/views.py
@@ -39,27 +39,29 @@ class ConcertListView(BaseView):
         These filters are accepted as query parameters in the GET URL, and are ANDed together.
 
     Request:
-        GET /concerts/?venues=15+24+13&dates=2016-03-28&genres=1+3+6
+        GET /concerts/?venues=15+24+13&dates=2016-03-28&genres=1+3+6&artists=15+22
 
     Response:
         A list of all Concerts
     """
     @authenticate
     def get(self, request):
+        # Our initial queryset is ALL concerts (this could be a lot)!
         queryset = Concert.objects.all()
 
         # Get all the possible filters and split them, making sure we get an
         # empty list if the parameter wasn't passed
-        venue_filters = filter(None,request.GET.get("venues", "").split("+"))
-        date_filters = filter(None,request.GET.get("dates", "").split("+"))
-        genre_filters = filter(None,request.GET.get("genres", "").split("+"))
-        artist_filters = filter(None,request.GET.get("artists", "").split("+"))
+        venue_filters = filter(None, request.GET.get('venues', '').split('+'))
+        date_filters = filter(None, request.GET.get('dates', '').split('+'))
+        genre_filters = filter(None, request.GET.get('genres', '').split('+'))
+        artist_filters = filter(None, request.GET.get('artists', '').split('+'))
 
         if venue_filters:
             queryset = queryset.filter(venue_id__in=venue_filters)
 
         if date_filters:
-            parsed_dates = [datetime.datetime.strptime("2016-03-28","%Y-%m-%d").date() for date in date_filters]
+            # Parse out the dates from this jawn
+            parsed_dates = [datetime.datetime.strptime(date, '%Y-%m-%d').date() for date in date_filters]
             queryset = queryset.filter(date__in=parsed_dates)
 
         if genre_filters:

--- a/jamjar/jamjar/urls.py
+++ b/jamjar/jamjar/urls.py
@@ -42,7 +42,7 @@ urlpatterns = patterns('',
     # Concert Views
     ########################################
     url(r'^concerts/$', Concerts.ConcertListView.as_view()),
-    url(r'^concerts/(?P<id>[0-9]+)/$', Concerts.ConcertView.as_view()),
+    url(r'^concerts/(?P<id>[0-9]+)/$', Concerts.ConcertDetailView.as_view()),
     url(r'^concerts/(?P<id>[0-9]+)/graph/$', Concerts.ConcertGraph.as_view()),
 
     ########################################

--- a/jamjar/jamjar/urls.py
+++ b/jamjar/jamjar/urls.py
@@ -43,7 +43,6 @@ urlpatterns = patterns('',
     ########################################
     url(r'^concerts/$', Concerts.ConcertListView.as_view()),
     url(r'^concerts/(?P<id>[0-9]+)/$', Concerts.ConcertDetailView.as_view()),
-    url(r'^concerts/(?P<id>[0-9]+)/graph/$', Concerts.ConcertGraph.as_view()),
 
     ########################################
     # Artist Views

--- a/jamjar/jamjar/videos/serializers.py
+++ b/jamjar/jamjar/videos/serializers.py
@@ -8,9 +8,6 @@ import os
 
 class VideoSerializer(serializers.ModelSerializer):
     artists = ArtistSerializer(many=True, read_only=True)
-    # artist_ids = serializers.serializers.ListField(
-    #   child=serializers.CharField()
-    # )
     user = UserSerializer(read_only=True, include_first_login=True)
 
     class Meta:


### PR DESCRIPTION
https://trello.com/c/X8HpZ4FP/27-concert-endpoint-revision

#### NOTE: THIS BRANCH WILL BREAK ALL THE THINGS!!!!

This branch revises the behavior of Concert endpoints in a bunch of ways.  The changes are as follows:
- The concert list endpoint will no longer serialize videos for each concert.  To get a list of videos, use the concert detail endpoint.
- Concerts will now be serialized with a `thumbs` field which will contain thumbnail sets from the first 3 videos in the concert
- Concerts will now serialize a list of artists which appear in the videos of the concert
- You may now filter the concert list by Venue, Date, Genre, and Artist (simultaneously) using query parameters
- The Concert Graph is now returned with the Concert Detail endpoint, so the graph endpoint is no longer needed O.o

These changes were made to improve endpoint efficiency, functionality, and clarity.  Please ask any questions below!

Gonna break all the things like
![kanye](https://media.giphy.com/media/Q5wEEjz5qx5rG/giphy.gif)