### PR TITLE
re-encode audio to 44100hz sample rate

### DIFF
--- a/jamjar/jamjar/tasks/transcode_video.py
+++ b/jamjar/jamjar/tasks/transcode_video.py
@@ -13,6 +13,8 @@ import hachoir_parser, hachoir_metadata
 
 import logging; logger = logging.getLogger(__name__)
 
+AUDIO_SAMPLE_RATE = '44100'
+
 class VideoTranscoder(object):
     "Helper class for transcoding, uploading, and fingerprinting"
 
@@ -29,11 +31,11 @@ class VideoTranscoder(object):
             try:
                 with open(os.devnull, "w") as devnull:
                     if extension == '.mov':
-                        subprocess.check_call(["avconv", "-i", src, '-c:v', 'libx264', '-c:a', 'copy', '-f', 'mp4', out], stdout=devnull, stderr=devnull)
+                        subprocess.check_call(["avconv", "-i", src, '-c:v', 'libx264', '-ar', AUDIO_SAMPLE_RATE, '-f', 'mp4', out], stdout=devnull, stderr=devnull)
                     elif extension == '.avi':
-                        subprocess.check_call(["avconv", "-i", src, '-c:v', 'libx264', '-crf', '20', '-b:a', '128k', '-strict', 'experimental', '-f', 'mp4', out], stdout=devnull, stderr=devnull)
+                        subprocess.check_call(["avconv", "-i", src, '-c:v', 'libx264', '-crf', '20', '-b:a', '128k', '-ar', AUDIO_SAMPLE_RATE, '-strict', 'experimental', '-f', 'mp4', out], stdout=devnull, stderr=devnull)
                     else:
-                        subprocess.check_call(["avconv", "-i", src, '-c:v', 'libx264', '-c:a', 'copy', '-f', 'mp4', out], stdout=devnull, stderr=devnull)
+                        subprocess.check_call(["avconv", "-i", src, '-c:v', 'libx264', '-ar', AUDIO_SAMPLE_RATE, '-f', 'mp4', out], stdout=devnull, stderr=devnull)
 
                 logger.info('Successfully transcoded {:} to {:}'.format(src, out))
                 return True


### PR DESCRIPTION
in practice, we found that normalizing the audio sample rate (for the outkast videos) resulted in higher stitching accuracy. The caveat here is that we can no longer just copy the audio track

Tested w/ `avi`, `mp4`, and `mov` files -- sample rate was successfuly converted to 44.1khz