### PR TITLE
Feature/genres endpoint

### DIFF
--- a/jamjar/jamjar/artists/serializers.py
+++ b/jamjar/jamjar/artists/serializers.py
@@ -11,6 +11,7 @@ class ArtistImageSerializer(serializers.ModelSerializer):
 class GenreSerializer(serializers.ModelSerializer):
     class Meta:
         model = Genre
+        fields = ('id','name')
 
 class ArtistSerializer(serializers.ModelSerializer):
     genres = serializers.SerializerMethodField()

--- a/jamjar/jamjar/artists/views.py
+++ b/jamjar/jamjar/artists/views.py
@@ -1,6 +1,6 @@
 from jamjar.base.views import BaseView, authenticate
-from jamjar.artists.models import Artist
-from jamjar.artists.serializers import ArtistSerializer
+from jamjar.artists.models import Artist, Genre
+from jamjar.artists.serializers import ArtistSerializer, GenreSerializer
 
 class ArtistSearchView(BaseView):
     serializer_class = ArtistSerializer
@@ -98,3 +98,23 @@ class ArtistListView(BaseView):
         self.serializer = self.get_serializer(artists,many=True)
 
         return self.success_response(self.serializer.data)
+
+class GenreView(BaseView):
+    serializer_class = GenreSerializer
+
+    """
+    Description:
+        Given a search string for an artist, search spotify and return the results
+        (To be used for Text Field autocompletion)
+
+    Request:
+        GET /artists/search/:search_string/
+
+    Response:
+        A list of all Artists matching that string
+    """
+    @authenticate
+    def get(self, request):
+        genres = Genre.objects.all()
+        self.serialzier = self.get_serializer(genres, many=True)
+        return self.success_response(self.serialzier.data)

--- a/jamjar/jamjar/artists/views.py
+++ b/jamjar/jamjar/artists/views.py
@@ -138,14 +138,14 @@ class GenreView(BaseView):
 
     """
     Description:
-        Given a search string for an artist, search spotify and return the results
-        (To be used for Text Field autocompletion)
+        Return a list of all genres associated with any artists in JamJar, as
+        well as their respective ID's
 
     Request:
         GET /genres/
 
     Response:
-        A list of all Artists matching that string
+        A list of all genres in jamjar
     """
     @authenticate
     def get(self, request):

--- a/jamjar/jamjar/concerts/views.py
+++ b/jamjar/jamjar/concerts/views.py
@@ -32,10 +32,11 @@ class ConcertListView(BaseView):
 
         # Get all the possible filters and split them, making sure we get an
         # empty list if the parameter wasn't passed
-        venue_filters = filter(None, request.GET.get('venues', '').split('+'))
-        date_filters = filter(None, request.GET.get('dates', '').split('+'))
-        genre_filters = filter(None, request.GET.get('genres', '').split('+'))
-        artist_filters = filter(None, request.GET.get('artists', '').split('+'))
+        # (Django turns pluses into spaces)
+        venue_filters = filter(None, request.GET.get('venues', '').split(' '))
+        date_filters = filter(None, request.GET.get('dates', '').split(' '))
+        genre_filters = filter(None, request.GET.get('genres', '').split(' '))
+        artist_filters = filter(None, request.GET.get('artists', '').split(' '))
 
         if venue_filters:
             queryset = queryset.filter(venue_id__in=venue_filters)
@@ -50,6 +51,8 @@ class ConcertListView(BaseView):
 
         if artist_filters:
             queryset = queryset.filter(videos__artists__id__in=artist_filters)
+
+        queryset = queryset.distinct()
 
         # Serialize the requests and return them
         self.serializer = self.get_serializer(queryset, many=True)

--- a/jamjar/jamjar/urls.py
+++ b/jamjar/jamjar/urls.py
@@ -49,6 +49,7 @@ urlpatterns = patterns('',
     ########################################
     url(r'^artists/search/(?P<search_string>.+)/$', Artists.ArtistSearchView.as_view()),
     url(r'^artists/$', Artists.ArtistListView.as_view()),
+    url(r'^genres/$', Artists.GenreView.as_view()),
 
     ########################################
     # Venue Views


### PR DESCRIPTION
https://trello.com/c/n5HZxRwm/57-genres-endpoint

This branch adds the genres endpoint to the API.  This can be used to display a list of all available genres to the user.  Since we only have the genres of the artists who are tagged in the currently added videos, we will just return those.  Once the genre ID's are gotten, they can be used to filter both artists and concerts using their respective endpoints.