### PR TITLE
Feature/videos endpoint

### DIFF
--- a/jamjar/jamjar/artists/views.py
+++ b/jamjar/jamjar/artists/views.py
@@ -27,7 +27,7 @@ class ArtistListView(BaseView):
     """
     Description:
         Get a list of all Artists in JamJar filtered by the following attributes:
-        - genre
+        - genres
 
         You may pass multiple of each filter, separated with a "+".
         These filters are accepted as query parameters in the GET URL, and are ANDed together.
@@ -40,7 +40,7 @@ class ArtistListView(BaseView):
     """
     @authenticate
     def get(self, request):
-        # Our initial queryset is ALL concerts (this could be a lot)!
+        # Our initial queryset is ALL artists (this could be a lot)!
         queryset = Artist.objects.all()
 
         # Get all the possible filters and split them, making sure we get an

--- a/jamjar/jamjar/urls.py
+++ b/jamjar/jamjar/urls.py
@@ -35,8 +35,10 @@ urlpatterns = patterns('',
     ########################################
     # Video Views
     ########################################
-    url(r'^videos/$', Videos.VideoList.as_view()),
-    url(r'^videos/(?P<id>[0-9]+)/$', Videos.VideoDetails.as_view()),
+    url(r'^videos/$', Videos.VideoListView.as_view()),
+    url(r'^videos/(?P<id>[0-9]+)/$', Videos.VideoDetailsView.as_view()),
+    url(r'^videos/(?P<id>[0-9]+)/watching/$', Videos.VideoWatchView.as_view()),
+
 
     ########################################
     # Concert Views

--- a/jamjar/jamjar/videos/migrations/0016_auto_20160412_0550.py
+++ b/jamjar/jamjar/videos/migrations/0016_auto_20160412_0550.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('videos', '0015_auto_20160411_0157'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='video',
+            options={'ordering': ['-created_at']},
+        ),
+    ]

--- a/jamjar/jamjar/videos/models.py
+++ b/jamjar/jamjar/videos/models.py
@@ -37,6 +37,9 @@ class Video(BaseModel):
     objects = PublicVideoManager()
     public_and_private_objects = models.Manager()
 
+    class Meta:
+        ordering = ['-created_at',]
+
     def get_video_dir(self):
         " Get the local directory for the video (and other temp files) "
         return '{:}/{:}'.format(settings.TMP_VIDEOS_PATH, self.uuid)

--- a/jamjar/jamjar/videos/serializers.py
+++ b/jamjar/jamjar/videos/serializers.py
@@ -15,6 +15,7 @@ class VideoSerializer(serializers.ModelSerializer):
         fields = ('id',
                   'name',
                   'uploaded',
+                  'created_at',
                   'uuid',
                   'length',
                   'file_size',

--- a/jamjar/jamjar/videos/views.py
+++ b/jamjar/jamjar/videos/views.py
@@ -236,14 +236,16 @@ class VideoWatchView(BaseView):
            at the same time
 
     Request:
-        GET /videos/:video_id/watching/
+        POST /videos/:video_id/watching/
+        {}
+        (No data needed)
 
     Response:
         True
     """
     # Don't authenticate this
     #@authenticate
-    def get(self, request, id):
+    def post(self, request, id):
         # Attempt to update the video count
         self.model.objects.filter(id=id).update(views=F('views')+1)
         return self.success_response(True)


### PR DESCRIPTION
https://trello.com/c/y1wGSenK/11-videos-endpoint-revision

This endpoint adds filtering of videos through the video GET endpoint.  Videos can no be filtered by genres, artists, and uploaders.  While they are normally ordered by last updated, I also added a "hot" filter which will return the Top 100 videos based on view count mixed with time. :fire: :fire: :fire: 

It also adds a view which should be hit when a video begins getting streamed in order to increment the view count (we made this as cheap as possible).