### PR TITLE
serialize concert in video responses

### DIFF
--- a/jamjar/jamjar/users/views.py
+++ b/jamjar/jamjar/users/views.py
@@ -83,7 +83,7 @@ class UserProfileView(BaseView):
         concerts = Concert.objects.filter(videos__user_id=user.id)
 
         user_serializer = UserSerializer(user)
-        video_serializer = VideoSerializer(videos, many=True, include_concert=True)
+        video_serializer = VideoSerializer(videos, many=True)
         concert_serializer = ConcertSerializer(concerts, many=True, expand_videos=False)
 
         response = {

--- a/jamjar/jamjar/videos/serializers.py
+++ b/jamjar/jamjar/videos/serializers.py
@@ -74,6 +74,33 @@ class VideoSerializer(serializers.ModelSerializer):
 
         return video
 
+class ExpandedVideoSerializer(VideoSerializer):
+    class Meta:
+        model = Video
+        fields = ('id',
+                  'name',
+                  'uploaded',
+                  'created_at',
+                  'uuid',
+                  'length',
+                  'file_size',
+                  'is_private',
+                  'views',
+                  'artists',
+                  'web_src',
+                  'hls_src',
+                  'thumb_src',
+                  'concert',
+                  'user',
+                  'width',
+                  'height')
+
+    def __init__(self, *args, **kwargs):
+        super(ExpandedVideoSerializer, self).__init__(*args, **kwargs)
+
+        from jamjar.concerts.serializers import ConcertSerializer
+        self.fields['concert'] = ConcertSerializer(read_only=True)
+
 class EdgeSerializer(serializers.ModelSerializer):
     video1 = VideoSerializer(read_only=True)
     video2 = VideoSerializer(read_only=True)

--- a/jamjar/jamjar/videos/serializers.py
+++ b/jamjar/jamjar/videos/serializers.py
@@ -12,7 +12,6 @@ class VideoSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Video
-        depth = 2 # traverse concert relation to get venue
         fields = ('id',
                   'name',
                   'uploaded',
@@ -32,11 +31,7 @@ class VideoSerializer(serializers.ModelSerializer):
                   'height')
 
     def __init__(self, *args, **kwargs):
-        self.include_concert = kwargs.pop('include_concert', False)
         super(VideoSerializer, self).__init__(*args, **kwargs)
-
-        if not self.include_concert:
-            self.fields.pop('concert')
 
     def validate(self, data):
         request = self.context.get('request')
@@ -71,8 +66,6 @@ class VideoSerializer(serializers.ModelSerializer):
         # Get the artists out of here beforehand
         artists = validated_data.pop('artist_objects',[])
 
-
-        import ipdb; ipdb.set_trace()
         # Call the super's 'create'
         video = super(VideoSerializer,self).create(validated_data)
 

--- a/jamjar/jamjar/videos/views.py
+++ b/jamjar/jamjar/videos/views.py
@@ -6,7 +6,7 @@ from django.db.models import F
 
 from jamjar.base.views import BaseView, authenticate
 from jamjar.videos.models import Video, Edge
-from jamjar.videos.serializers import VideoSerializer, EdgeSerializer
+from jamjar.videos.serializers import VideoSerializer, ExpandedVideoSerializer, EdgeSerializer
 
 from jamjar.concerts.serializers import ConcertSerializer
 from jamjar.concerts.models import Concert
@@ -69,16 +69,9 @@ class VideoListView(BaseView):
             queryset = sorted(queryset, key= lambda v: v.hot(now), reverse=True)
 
 
-        serializer = self.get_serializer(queryset, many=True)
-        videos = serializer.data
+        expanded_serializer = ExpandedVideoSerializer(queryset, many=True)
 
-        for video in videos:
-          concert = Concert.objects.get(pk=video['concert'])
-          concert_serializer = ConcertSerializer(concert)
-
-          video['concert'] = concert_serializer.data
-
-        return self.success_response(videos)
+        return self.success_response(expanded_serializer.data)
 
     """
     Description:
@@ -193,13 +186,8 @@ class VideoListView(BaseView):
         # do this async. TODO : change lilo to use Integers for the video_id field
         transcode_video.delay(video.id)
 
-        concert = Concert.objects.get(pk=video.concert_id)
-        concert_serializer = ConcertSerializer(concert)
-
-        video_data = self.serializer.data
-        video_data['concert'] = concert_serializer.data
-
-        return self.success_response(video_data)
+        expanded_serializer = ExpandedVideoSerializer(video)
+        return self.success_response(expanded_serializer.data)
 
 
 class VideoDetailsView(BaseView):
@@ -213,15 +201,9 @@ class VideoDetailsView(BaseView):
         self.video = self.get_object_or_404(self.model, id=id)
 
         # Serialize the result and return it
-        self.serializer = self.get_serializer(self.video)
+        self.serializer = ExpandedVideoSerializer(self.video)
 
-        video = self.serializer.data
-
-        concert = Concert.objects.get(pk=video['concert'])
-        concert_serializer = ConcertSerializer(concert)
-        video['concert'] = concert_serializer.data
-
-        return self.success_response(video)
+        return self.success_response(self.serializer.data)
 
     @authenticate
     def put(self, request, id):


### PR DESCRIPTION
@markkohdev this works but is not great. LMK if you have thoughts about how we could do it better

Tested:
 - video details view
 - video list view
 - upload view

all requests return 200 OK and their responses contain a `concerts` blob