### PR TITLE
copy codecs for hls

### DIFF
--- a/jamjar/jamjar/tasks/transcode_video.py
+++ b/jamjar/jamjar/tasks/transcode_video.py
@@ -64,7 +64,7 @@ class VideoTranscoder(object):
 
         try:
             with open(os.devnull, "w") as devnull:
-              subprocess.check_call(['avconv', '-i', src, '-strict', 'experimental', '-start_number', '0', '-hls_list_size', str(HLS_MAX_SEGMENTS), '-hls_time', str(HLS_SEGMENT_LENGTH_SECONDS), '-f', 'hls', out], stdout=devnull, stderr=devnull)
+              subprocess.check_call(['avconv', '-i', src, '-codec', 'copy', '-bsf:v', 'h264_mp4toannexb', '-strict', 'experimental', '-start_number', '0', '-hls_list_size', str(HLS_MAX_SEGMENTS), '-hls_time', str(HLS_SEGMENT_LENGTH_SECONDS), '-f', 'hls', out], stdout=devnull, stderr=devnull)
             logger.info('Successfully transcoded {:} to {:}'.format(src, out))
             return True
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Previously, we re-encoded the converted mp4 file to HLS format. Fortunately for us, HLS is basically just h.264/aac with a manifest file (.m3u8). So as long as we always do

source_video --> mp4_video --> hls_video

there's no need to re-encode the video. We just need to change the wrapper to hls which avconv is nice enough to do for us. On my 30% CPU vm, this takes the transcoding process from 9 minutes to 4 seconds #LOL 

This is notoriously tricky for us, so we should of course test thoroughly. I did a couple of quick tests though, and it seems to work just fine!